### PR TITLE
Use Ubuntu 20.04 to build Linux binaries

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,7 @@ jobs:
 
 
   vcpkg_linux-x64:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -68,7 +68,7 @@ jobs:
 
 
   vcpkg_linux-arm64:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Ubuntu 22.04 is too modern, it makes the library not work on a system without glibc 2.34.